### PR TITLE
meta-qcom qli-2.0-rc1 release

### DIFF
--- a/lock.yml
+++ b/lock.yml
@@ -11,11 +11,11 @@ repos:
     url: https://github.com/AudioReach/meta-audioreach
   meta-openembedded:
     branch: master
-    commit: e19775fba85e966d482ac7bee933754863e3acfe
+    commit: 4d60ca97ec2f0a7a22ac35a97f716544b54fbe39
     url: https://github.com/openembedded/meta-openembedded
   meta-qcom:
     branch: master
-    commit: 49bc2113adb0b86d463c311d32d4fb1007fe4845
+    commit: daf8c98ae0042b53140ea7f335cf8516eecf1fce
     url: https://github.com/qualcomm-linux/meta-qcom
   meta-qcom-distro:
     branch: main


### PR DESCRIPTION
Preview for RC1 meta-qcom release

Each release will update the revisions in the kas lock file labelled `lock.yml`. 

The commit will be tagged with `<release-tag>` and the commit message will follow the format: `meta-qcom <release-tag> release`.

We can add any metadata required in the commit body. Eg. 
`Nightly-Build: https://github.com/qualcomm-linux/meta-qcom/actions/runs/22245353486/attempts/2`