### PR TITLE
fix the build path passed to oe-init-build-env

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -154,8 +154,8 @@ init_env() {
 
   log "INFO" "Initializing bitbake environment."
   # switch to oe-core directory, so oe-init-build-env can figure out OEROOT correctly
-  cd  "${PWD}/oe-core"
   set -- "$PWD/build"
+  cd  "${PWD}/oe-core"
   . "$PWD/oe-init-build-env"
 }
 


### PR DESCRIPTION
The local.conf and bblayers.conf files are generated in the build directory by kas. However, the script was passing an incorrect build path to oe-init-build-env, causing these existing configuration files to be ignored.