### PR TITLE
meta-qcom qli-2.0-rc2 release

### DIFF
--- a/lock.yml
+++ b/lock.yml
@@ -3,23 +3,23 @@ header:
 repos:
   bitbake:
     branch: master
-    commit: 1f8fa7c25e71cd0f230a2f6bfd9d5153c694da81
+    commit: b54600e37073a83be1d0490bb16039df73f09c83
     url: https://github.com/openembedded/bitbake
   meta-audioreach:
     branch: master
-    commit: e2d213083b6374a5cc285f86438878896693678b
+    commit: 1e91ad67c8c6a62cee4ef92761f022a459d1aa8a
     url: https://github.com/AudioReach/meta-audioreach
   meta-openembedded:
     branch: master
-    commit: e19775fba85e966d482ac7bee933754863e3acfe
+    commit: 0bc67b61ca52e85a5a882d809ba0c98d21cceac8
     url: https://github.com/openembedded/meta-openembedded
   meta-qcom:
     branch: master
-    commit: e4003a8f1c5545610482af1ac60517c7a4352394
+    commit: 678d9b8ef56c0f48af8527af86c557bacca0593b
     url: https://github.com/qualcomm-linux/meta-qcom
   meta-qcom-distro:
     branch: main
-    commit: 062201e74e5331b1e4053aa1f716f3077d7b2c6f
+    commit: 7b8c20153b11bd4ede24b735a8a5527edf1d4d6e
     url: https://github.com/qualcomm-linux/meta-qcom-distro
   meta-security:
     branch: master
@@ -31,17 +31,13 @@ repos:
     url: https://git.yoctoproject.org/meta-selinux
   meta-updater:
     branch: master
-    commit: 8ef3734055e7ffbf34df557db68e41fe418662f7
+    commit: 671d459917f140db7edf56295aa4dce8a743ea73
     url: https://github.com/uptane/meta-updater
   meta-virtualization:
     branch: master
-    commit: 1be0a5e3170ee32073377033d3e1f2186b4f622f
+    commit: ebe61f2aee8afe4caaa0e2327b8a02c0ded4e330
     url: https://git.yoctoproject.org/git/meta-virtualization
-  meta-yocto:
-    branch: master
-    commit: f3b63d0d6882af61020bd6f7150fae68a0322f63
-    url: https://git.yoctoproject.org/meta-yocto
   oe-core:
     branch: master
-    commit: b8e48562ba273051bcf8cbc62be742ef42a1e622
+    commit: 57fe3e411faec8cc60853f2e499661f9ede4f453
     url: https://github.com/openembedded/openembedded-core


### PR DESCRIPTION
Based on meta-qcom nightly [#420](https://github.com/qualcomm-linux/meta-qcom/actions/runs/22923094013).