### PR TITLE
ci: Enable weekly ci builds for release tags

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -1,0 +1,70 @@
+name: Run kas for a specific build configuration
+inputs:
+  machine:
+    required: true
+  distro_yaml:
+    required: true
+  kas:
+    required: true
+  tag:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Clone meta-qcom-releases
+      id: clone
+      shell: bash
+      run: |
+        echo "Processing tag: $INPUTS_TAG"
+        
+        BUILD_DIR="build-$INPUTS_TAG"
+        mkdir -p "$BUILD_DIR"
+        cd "$BUILD_DIR"
+        
+        echo "Cloning meta-qcom-releases repository with branch: $INPUTS_TAG"
+        if ! git clone https://github.com/qualcomm-linux/meta-qcom-releases -b "$INPUTS_TAG" meta-qcom-releases; then
+          echo "Error: Failed to clone branch $INPUTS_TAG from meta-qcom-releases"
+          echo "Available branches:"
+          git ls-remote --heads https://github.com/qualcomm-linux/meta-qcom-releases
+          exit 1
+        fi
+        
+        if [ ! -f meta-qcom-releases/lock.yml ]; then
+          echo "Error: lock.yml not found in meta-qcom-releases for branch $INPUTS_TAG"
+          exit 1
+        fi
+        
+        echo "build_dir=$BUILD_DIR" >> $GITHUB_OUTPUT
+      env:
+        INPUTS_TAG: ${{ inputs.tag }}
+
+    - name: Copy lock.yml
+      shell: bash
+      run: |
+        cd "$BUILD_DIR"
+        
+        echo "Copying lock.yml for tag: $INPUTS_TAG"
+        $KAS checkout meta-qcom-releases/lock.yml
+        
+        cp meta-qcom-releases/lock.yml meta-qcom/ci/lock.yml
+      env:
+        KAS: ${{ inputs.kas }}
+        INPUTS_TAG: ${{ inputs.tag }}
+        BUILD_DIR: ${{ steps.clone.outputs.build_dir }}
+
+    - name: Kas build
+      shell: bash
+      run: |
+        cd "$BUILD_DIR"
+        
+        echo "Building for tag: $INPUTS_TAG"
+        $KAS build meta-qcom/ci/$INPUTS_MACHINE.yml:meta-qcom/ci/$INPUTS_DISTRO_YAML:meta-qcom/ci/lock.yml
+        
+        echo "Completed build for tag: $INPUTS_TAG"
+      env:
+        INPUTS_MACHINE: ${{ inputs.machine }}
+        INPUTS_DISTRO_YAML: ${{ inputs.distro_yaml }}
+        KAS: ${{ inputs.kas }}
+        INPUTS_TAG: ${{ inputs.tag }}
+        BUILD_DIR: ${{ steps.clone.outputs.build_dir }}

--- a/.github/workflows/Readme.md
+++ b/.github/workflows/Readme.md
@@ -4,3 +4,4 @@ This folder contains workflows that are helpful for maintaining a smooth and sec
 Workflows:
 1. `qcom-preflight-checks.yml` - This workflow runs several preflight checks, including copyight, email, repolinter, and security checks.  See [qualcomm/qcom-actions](https://github.com/qualcomm/qcom-actions)
 2. `stale-issues.yaml` - This workflow will periodically run every 30 days to check for stalled issues and PRs. If the workflow detects any stalled issues and/or PRs, it will automatically leave just a comment to draw attention.
+3. `weekly-build.yml` - This workflow will run weekly and do kas build for all release tags present till date in the repo.

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -1,0 +1,65 @@
+name: Build Yocto
+
+on:
+  workflow_call:
+    inputs:
+      release_tags:
+        description: 'Comma separated tag values'
+        type: string
+        required: false
+        default: ""
+
+jobs:
+  prepare:
+    if: github.repository_owner == 'qualcomm-linux'
+    runs-on: [self-hosted, qcom-u2404, amd64]
+    outputs:
+      tags: ${{ steps.fetch_tags.outputs.tags_json }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch tags to build
+        id: fetch_tags
+        shell: bash
+        run: |
+          if [[ -n "$RELEASE_TAGS" ]]; then
+            TAGS=$(echo "$RELEASE_TAGS" | tr ',' '\n' | xargs -I{} echo "{}" | sort -V)
+          else
+            git fetch --tags
+            TAGS=$(git tag --sort=v:refname)
+          fi
+          TAGS_JSON=$(echo "$TAGS" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "tags_json=$TAGS_JSON" >> $GITHUB_OUTPUT
+        env:
+          RELEASE_TAGS: ${{ inputs.release_tags }}
+
+  compile:
+    needs: prepare
+    if: github.repository_owner == 'qualcomm-linux'
+    runs-on: [self-hosted, qcom-u2404, amd64]
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJson(needs.prepare.outputs.tags) }}
+    name: Build ${{ matrix.tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set env variables
+        run: |
+          mkdir -p kas-work
+          echo "KAS_CONTAINER=$PWD/kas-work/kas-container" >> $GITHUB_ENV
+
+      - name: Setup kas-container
+        run: |
+          LATEST=$(git ls-remote --tags --refs --sort="v:refname" https://github.com/siemens/kas | tail -n1 | sed 's/.*\///')
+          wget -qO ${KAS_CONTAINER} https://raw.githubusercontent.com/siemens/kas/refs/tags/$LATEST/kas-container
+          chmod +x ${KAS_CONTAINER}
+
+      - name: Run kas build for tag ${{ matrix.tag }}
+        uses: ./.github/actions/compile
+        with:
+          machine: rb3gen2-core-kit
+          distro_yaml: qcom-distro-prop-image.yml
+          kas: ${{ env.KAS_CONTAINER }}
+          tag: ${{ matrix.tag }}

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -1,0 +1,18 @@
+name: Weekly Build
+
+on:
+  workflow_dispatch:
+  schedule:
+  # NOTE - changes to the cron spec should be pushed by https://github.com/quic-yocto-ci
+  # so that build notification emails will be sent out properly.
+  - cron: "30 11 * * 0"   # weekly job - Run at 11:30 UTC every Sunday
+
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+  packages: read
+
+jobs:
+  build-weekly:
+    uses: ./.github/workflows/build-yocto.yml


### PR DESCRIPTION
Enabled weekly ci builds for all exisiting tags on meta-qcom-releases