### PR TITLE
meta-qcom qli-2.0-rc3 release

### DIFF
--- a/lock.yml
+++ b/lock.yml
@@ -3,41 +3,41 @@ header:
 repos:
   bitbake:
     branch: master
-    commit: b54600e37073a83be1d0490bb16039df73f09c83
+    commit: 5d722b5d65e4eef7befe6376983385421e993f86
     url: https://github.com/openembedded/bitbake
   meta-audioreach:
     branch: master
-    commit: 1e91ad67c8c6a62cee4ef92761f022a459d1aa8a
+    commit: 75402c8d1ea1203dcf3a63792161f7d5d93946bb
     url: https://github.com/AudioReach/meta-audioreach
   meta-openembedded:
     branch: master
-    commit: 0bc67b61ca52e85a5a882d809ba0c98d21cceac8
+    commit: d2e6069771e435231a220a8ecac20c0e7ceff037
     url: https://github.com/openembedded/meta-openembedded
   meta-qcom:
     branch: master
-    commit: cc27172f1427e3d79ee180b8155ae1c9b12e831f
+    commit: 6f9d1c4abb6af7d9b5f07348d0f0b2031b305930
     url: https://github.com/qualcomm-linux/meta-qcom
   meta-qcom-distro:
     branch: main
-    commit: c1cfd6731643f5110f497874ca04963b6a733b1c
+    commit: df48923e77aa9c5f3ddace8e01fa38963bc90c9b
     url: https://github.com/qualcomm-linux/meta-qcom-distro
   meta-security:
     branch: master
-    commit: 9e6d962250aab6e5319215f15b0201ef233c46cd
+    commit: 596b966a0d047c2f48cb768821558e918ae0c477
     url: https://git.yoctoproject.org/meta-security
   meta-selinux:
     branch: master
-    commit: 27758bca5ad8f74f387de5cc7c88e73ef2aed951
+    commit: 4904b87b12c51a68efc5b9cd45c7b519fdc48af1
     url: https://git.yoctoproject.org/meta-selinux
   meta-updater:
     branch: master
-    commit: fdc475db4833f5edfb4417d40ecea00fc2af7cbf
+    commit: d713c99a9ddace090c0efc0ed57022185daa6fb2
     url: https://github.com/uptane/meta-updater
   meta-virtualization:
     branch: master
-    commit: 947678262ae85f214a306ff41d7352485c8d5a03
+    commit: 4e6c583591c1da7e898254dd33eca5cc04c739a9
     url: https://git.yoctoproject.org/git/meta-virtualization
   oe-core:
     branch: master
-    commit: 57fe3e411faec8cc60853f2e499661f9ede4f453
+    commit: 8c008f36d7af1e63cb3f4a2ba763efd1f1e5fe4d
     url: https://github.com/openembedded/openembedded-core


### PR DESCRIPTION
Based on meta-qcom nightly run #504
https://github.com/qualcomm-linux/meta-qcom/actions/runs/24745158985