### PR TITLE
ci: update kas distro fragment for weekly builds

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -60,6 +60,6 @@ jobs:
         uses: ./.github/actions/compile
         with:
           machine: rb3gen2-core-kit
-          distro_yaml: qcom-distro-prop-image.yml
+          distro_yaml: qcom-distro.yml
           kas: ${{ env.KAS_CONTAINER }}
           tag: ${{ matrix.tag }}


### PR DESCRIPTION
qcom-distro-prop-image.yml targets were merged into qcom-distro.yml in RC3. qcom-distro.yml kas fragment can be used for building all tags for weekly builds.