### PR TITLE
scripts: remove kas skip flags to enable patching

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -161,10 +161,6 @@ init_env() {
   # parse and generate kas configuration
   echo "INFO: Generating temporary kas configuration."
   kas -l error dump \
-    --skip repo_setup_loop \
-    --skip finish_setup_repos \
-    --skip repos_checkout \
-    --skip repos_apply_patches \
     "$CONFIG_FILES" > .config.yaml || \
   {
     cleanup
@@ -174,12 +170,9 @@ init_env() {
 
   # invoking kas shell should auto-generate BitBake configuration
   # based on the kas local_conf_header
+  echo "WARNING: The workspace repositories will be reset to their initial state and patches will be applied."
   echo "INFO: Setting up bitbake configuration."
   kas -l error shell \
-    --skip repo_setup_loop \
-    --skip finish_setup_repos \
-    --skip repos_checkout \
-    --skip repos_apply_patches \
     "$CONFIG_FILES" -c "exit 0" || \
   {
     cleanup

--- a/setup-environment
+++ b/setup-environment
@@ -114,6 +114,20 @@ cleanup() {
   unset MACHINE DISTRO KERNEL CONFIG_FILES SKIP_SETUP KAS_BUILD_DIR
 }
 
+# Repos synced via 'repo' tool use non-standard remote names instead of
+# 'origin'. Add an 'origin' alias so kas can operate on the meta layers
+# already synced to the workspace.
+ensure_origin_remotes() {
+  for repo_dir in */; do
+    [ -d "${repo_dir}.git" ] || continue
+    git -C "$repo_dir" remote | grep -q '^origin$' && continue
+    remote=$(git -C "$repo_dir" remote | head -1)
+    [ -z "$remote" ] && continue
+    url=$(git -C "$repo_dir" remote get-url "$remote" 2>/dev/null) || continue
+    git -C "$repo_dir" remote add origin "$url"
+  done
+}
+
 init_env() {
   parse_args "$@" || return $?
 
@@ -125,6 +139,9 @@ init_env() {
 
   echo "INFO: Running validation checks."
   validation_checks || return $?
+
+  echo "INFO: Ensuring repos have an 'origin' remote."
+  ensure_origin_remotes
 
   CONFIG_FILES="$MACHINE:$DISTRO"
   if [ -n "$KERNEL" ]; then

--- a/setup-environment
+++ b/setup-environment
@@ -165,7 +165,7 @@ init_env() {
     --skip repos_apply_patches \
     "$CONFIG_FILES" > .config.yaml || \
   {
-    cleanup 
+    cleanup
     echo "ERROR: Failure while parsing kas configuration."
     return 1
   }
@@ -173,7 +173,7 @@ init_env() {
   echo "INFO: Exporting environment variables from kas configuration."
   eval "$(parse_env_vars .config.yaml)" || \
   {
-    cleanup 
+    cleanup
     echo "ERROR: Failure during environment variable setup."
     return 1
   }

--- a/setup-environment
+++ b/setup-environment
@@ -158,6 +158,20 @@ init_env() {
   }
   export KAS_BUILD_DIR
 
+  # parse and generate kas configuration
+  echo "INFO: Generating temporary kas configuration."
+  kas -l error dump \
+    --skip repo_setup_loop \
+    --skip finish_setup_repos \
+    --skip repos_checkout \
+    --skip repos_apply_patches \
+    "$CONFIG_FILES" > .config.yaml || \
+  {
+    cleanup
+    echo "ERROR: Failure while parsing kas configuration."
+    return 1
+  }
+
   # invoking kas shell should auto-generate BitBake configuration
   # based on the kas local_conf_header
   echo "INFO: Setting up bitbake configuration."
@@ -170,20 +184,6 @@ init_env() {
   {
     cleanup
     echo "ERROR: Failure during bitbake configuration setup."
-    return 1
-  }
-
-  # parse and generate kas configuration
-  echo "INFO: Generating temporary kas configuration."
-  kas -l error dump \
-    --skip repo_setup_loop \
-    --skip finish_setup_repos \
-    --skip repos_checkout \
-    --skip repos_apply_patches \
-    "$CONFIG_FILES" > .config.yaml || \
-  {
-    cleanup
-    echo "ERROR: Failure while parsing kas configuration."
     return 1
   }
 


### PR DESCRIPTION
meta-qcom may contain patches for upstream meta-layers needed to correctly compile the image. Remove the skip flags, so kas can apply patches to meta layers in the workspace.
