### PR TITLE
scripts: add support for meta-qcom-extras

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -131,6 +131,23 @@ init_env() {
     CONFIG_FILES="$CONFIG_FILES:$KERNEL"
   fi
 
+  case "$CONFIG_FILES" in
+    meta-qcom-extras/*)
+        [ -d meta-qcom-extras ] || \
+        {
+          cleanup
+          echo "ERROR: meta-qcom-extras needs to be part of the workspace"
+          return 1
+        }
+        meta-qcom-extras/setup_extras_config.sh || \
+        {
+          cleanup
+          echo "ERROR: meta-qcom-extras parameters need to be configured"
+          return 1
+        }
+      ;;
+  esac
+
   # Temporary build directory should be in the same path
   # to ensure bblayers.conf relative referencing is consistent
   KAS_BUILD_DIR="$(mktemp -d -p "$PWD")" || \


### PR DESCRIPTION
Add the extra build steps needed when compiling meta-qcom-extras.

Users can pass kas configuration files from the `meta-qcom-extras/ci directory` to compile meta-qcom-extras targets.

Example:
  source setup-environment \
    --machine meta-qcom-extras/ci/iq-9075-evk.yml \
    --distro meta-qcom-extras/ci/qcom-distro.yml

Depends-on: #21 